### PR TITLE
Removed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 ### Web Applications:
 
 - [Build a Microblog with Flask](https://blog.miguelgrinberg.com/post/the-flask-mega-tutorial-part-i-hello-world)
-- Create a Blog Web App In Django
-  - [Part I : Introduction](https://tutorial.djangogirls.org/en/)
-  - [Part II : Extension To Add More Features](https://legacy.gitbook.com/book/djangogirls/django-girls-tutorial-extensions/details)
+- [Create a Blog Web App In Django](https://tutorial.djangogirls.org/en/)
 - [Choose Your Own Adventure Presentations](https://www.twilio.com/blog/2015/03/choose-your-own-adventures-presentations-wizard-mode-part-1-of-3.html)
 - [Build a Todo List with Flask and RethinkDB](https://realpython.com/blog/python/rethink-flask-a-simple-todo-list-powered-by-flask-and-rethinkdb/)
 - [Build a Todo List with Django and Test-Driven Development](http://www.obeythetestinggoat.com/)


### PR DESCRIPTION
Removed broken link from Create a Web App in Django (Issue #285)

## Description
Removed Part 1 and Part 2 headings from Create a Web App in Django entry and added the relevant link to the heading as suggested [here](https://github.com/practical-tutorials/project-based-learning/issues/285)

## Motivation and Context
It removes a broken link and fixes the issue at this link: https://github.com/practical-tutorials/project-based-learning/issues/285

## How Has This Been Tested?
Tested the link and layout by taking a look at my fork's readme after adding the changes.

## Types of changes
- [x] Content Update (change which fixes an issue or updates an already existing submission)
- [ ] New Article (change which adds functionality)
- [ ] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have made checks to ensure URLs and other resources are valid
