### PR TITLE
Added tutorial - Recreacting the linux 'which' command in go - Beginner friendly tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 - [Building a TCP Chat in Go(video)](https://www.youtube.com/watch?v=Sphme0BqJiY)
 - [Building a BitTorrent client from the ground up in Go](https://blog.jse.li/posts/torrent/)
 - [REST API masterclass with Go, PostgreSQL and Docker(video playlist)`in progress`](https://www.youtube.com/watch?v=rx6CPDK_5mU&list=PLy_6D98if3ULEtXtNSY_2qN21VCKgoQAE)
+- [Recreating the Linux 'Which' Command in Go](https://aubiss.com/posts/recreating-which-command-in-go/)
 
 ## PHP:
 


### PR DESCRIPTION
## Description
I'd like to contribute to the repo by adding my own tutorial (recreating the Linux which command in go), it's a beginner friendly detailed step by step guide to recreate the Linux 'which' command from scratch.

## Motivation and Context
Hopefully this tutorial will help beginners get a fundamental understanding of some Go concepts in a practical, hands-on manner.

How Has This Been Tested?
I wrote it myself.

## Types of changes
 
- [x] New Article (change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have made checks to ensure URLs and other resources are valid