### PR TITLE
Include project-based Three.js learning resources in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,11 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 - [Learn D3 using examples](https://www.sitepoint.com/d3-js-data-visualizations/)
 - [Learn To Make A Line Chart](https://medium.freecodecamp.org/learn-to-create-a-line-chart-using-d3-js-4f43f1ee716b)
 
+#### Three.js
+
+- [Learn Three.js by building 5 projects - FreeCodeCamp.org](https://www.youtube.com/watch?v=UMqNHi1GDAE&t=35s)
+- [23 Cool Three.js Projects - Robot Bobby](https://www.youtube.com/watch?v=63o2gHHgeH4)
+
 ### Game Development:
 
 - [Make 2D Breakout Game using Phaser](https://developer.mozilla.org/en-US/docs/Games/Tutorials/2D_breakout_game_Phaser)


### PR DESCRIPTION
Add Three.js section with learning resources

## Description
Added a new section `### Three.js` in the README that includes useful YouTube tutorials to help aspiring developers learn Three.js by building projects.

## Motivation and Context
Three.js is a popular JavaScript library for 3D graphics on the web. Including tutorials provides aspiring developers with structured resources to start learning and building projects from scratch, which aligns with the repo’s goal of offering practical application-building tutorials.

## How Has This Been Tested?
- Verified that the links are correct and lead to the intended YouTube tutorials.
- Previewed the README to ensure proper Markdown formatting and link rendering.

## Types of changes
- [x] Content Update (change which fixes an issue or updates an already existing submission)
- [ ] New Article (change which adds functionality)
- [x] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have made checks to ensure URLs and other resources are valid
