### PR TITLE
Fix broken link for Search Engine tutorial (Fixes #380)

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 - [Build a Simple Blockchain in Python](https://hackernoon.com/learn-blockchains-by-building-one-117428612f46)
 - [Write a NoSQL Database in Python](https://jeffknupp.com/blog/2014/09/01/what-is-a-nosql-database-learn-by-writing-one-in-python/)
 - [Building a Gas Pump Scanner with OpenCV/Python/iOS](https://hackernoon.com/building-a-gas-pump-scanner-with-opencv-python-ios-116fe6c9ae8b)
-- [Build a Distributed Streaming System with Python and Kafka](https://codequs.com/p/S14jQ5UyG/build-a-distributed-streaming-system-with-apache-kafka-and-python)
+- [Build a Distributed Streaming System with Python and Kafka](https://medium.com/@kevin.michael.horan/distributed-video-streaming-with-python-and-kafka-551de69fe1dd)
 - [Writing a basic x86-64 JIT compiler from scratch in stock Python](https://csl.name/post/python-jit/)
 - Making a low level (Linux) debugger
   - [Part 1](https://blog.asrpo.com/making_a_low_level_debugger)


### PR DESCRIPTION
## Description
I identified a broken link in the **Python** section for the "Distributed Streaming Service with Python and Kafka" tutorial. I have replaced the dead link with a working Medium article that covers the same topic.

**New Link:** https://medium.com/@kevin.michael.horan/distributed-video-streaming-with-python-and-kafka-551de69fe1dd

## Motivation and Context
The previous link was dead (returning an error), making the tutorial inaccessible to learners. This update ensures the resource list remains useful and accurate.
Closes #380

## How Has This Been Tested?
I manually clicked the new link to verify that it is active, accessible, and contains the relevant tutorial content described in the list and on of the topic Distributed streaming service with python and kafka.

## Types of changes
- [x] Content Update (change which fixes an issue or updates an already existing submission)
- [ ] New Article (change which adds functionality)
- [ ] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
