### PR TITLE
Clarify how to suggest improvements to contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,15 @@ Before making a pull request, please make sure of the following:
 * Check the spelling and grammar
 * Do the work, write good commit messages, and read the CONTRIBUTING file if there is one
 * Remove any trailing whitespaces
-* Links must be pointing straight to the tutorials, no URL shorteners. However, if the URL is too long (more than 80 characters), Google URL Shortener is allowed
+* Links must be pointing straight to the tutorials, no URL shorteners. However, if the URL is too long (more than 80 characters), Google URL Shortener is allowed.
+
+### Pull request etiquette
+
+Please keep pull requests focused and limited to a single change where possible. Be open to feedback and requested changes, and note that not all submissions may be accepted.
+
+### Improving these guidelines
+
+If you have suggestions to improve this document or the contribution process, feel free to open an issue or submit a pull request explaining your proposal. For small improvements such as wording or clarity fixes, a direct pull request is welcome.
+
 
 Thank you for your suggestions! If you think there is anything to improve with the guidelines, please contact me at <tuvtran97@gmail.com>


### PR DESCRIPTION
This PR adds a short section explaining how contributors can propose improvements to the contribution guidelines themselves.
