### PR TITLE
Fix broken link: Update Mask detection PyTorch Lightning tutorial URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 - [Code a Smile Classifier using CNNS in Python](https://github.com/kylemcdonald/SmileCNN)
 - [Natural Language Processing using scikit-learn](https://towardsdatascience.com/natural-language-processing-count-vectorization-with-scikit-learn-e7804269bb5e)
 - [Code a Taylor Swift Lyrics Generator](https://towardsdatascience.com/ai-generates-taylor-swifts-song-lyrics-6fd92a03ef7e)
-- [Mask detection using PyTorch Lightning](https://towardsdatascience.com/how-i-built-a-face-mask-detector-for-covid-19-using-pytorch-lightning-67eb3752fd61)
+- [Mask detection using PyTorch Lightning](https://towardsdatascience.com/creating-a-powerful-covid-19-mask-detection-tool-with-pytorch-d961b31dcd45)
 
 ### Miscellaneous:
 


### PR DESCRIPTION
## Description
Fixes broken link for "Mask detection using PyTorch Lightning" tutorial in the Deep Learning section.

## Problem
The original link was returning a 404 error: 
`https://towardsdatascience.com/how-i-built-a-face-mask-detector-for-covid-19-using-pytorch-lightning-67eb3752fd61`

## Solution
Updated to a working TowardsDataScience tutorial that covers similar content: 
`https://towardsdatascience.com/creating-a-powerful-covid-19-mask-detection-tool-with-pytorch-d961b31dcd45`

The new tutorial also demonstrates COVID-19 mask detection using PyTorch and is a suitable replacement. 

## Testing
- [x] Verified the new link loads successfully
- [x] Confirmed the content is relevant (PyTorch mask detection)
- [x] Checked markdown formatting is correct

## Issue Reference
Closes #788