### PR TITLE
Add WhatsApp Bot tutorial link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 ### Bots:
 
+- [Build a WhatsApp Bot with Python and Twilio](https://www.twilio.com/docs/whatsapp/tutorial/send-and-receive-media-messages-whatsapp-python)
 - [Build a Reddit Bot](http://pythonforengineers.com/build-a-reddit-bot-part-1/)
 - [How to Make a Reddit Bot - YouTube](https://www.youtube.com/watch?v=krTUf7BpTc0) (video)
 - [Build a Facebook Messenger Bot](https://blog.hartleybrody.com/fb-messenger-bot/)


### PR DESCRIPTION
Add Python WhatsApp Bot tutorial using Twilio

## Description
Added a project-based Python tutorial that demonstrates how to build a WhatsApp bot using Twilio. The link has been placed under the Python (Bots) section in the README.

## Motivation and Context
This change adds a practical automation project to the Python section, helping learners build real-world WhatsApp bots using Python and Twilio. It expands the existing collection of Python automation resources.

## How Has This Been Tested?
Manually verified that the tutorial link is accessible, relevant, and not already present in the repository.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Content Update
- [x] New Article
- [x] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have made checks to ensure URLs and other resources are valid
