### PR TITLE
fix: update broken Java tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 - [Build an Interpreter](http://www.craftinginterpreters.com/) (Chapter 4-13 is written in Java)
 - [Build a Simple HTTP Server with Java](http://javarevisited.blogspot.com/2015/06/how-to-create-http-server-in-java-serversocket-example.html)
 - [Build an Android Flashlight App](https://www.youtube.com/watch?v=dhWL4DC7Krs) (video)
-- [Build a Spring Boot App with User Authentication](https://spring.io/guides/gs/securing-web/)
+- [Build a Spring Boot App with User Authentication](https://www.youtube.com/watch?v=KYNR5js2cXE)(video)
 
 ## JavaScript:
 


### PR DESCRIPTION
This updates the broken link for the "Build a Spring Boot App with User Authentication" entry under the Java tutorials. The original link was no longer available, so it has been replaced with a working alternative. This resolves issue #347.
signed-off-by: Keerthi Raja<srikeera@gmail.com>