### PR TITLE
Add FastAPI tutorial to Python Web Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
   - [Part 4](https://danidee10.github.io/2018/01/10/realtime-django-4.html)
   - [Part 5](https://danidee10.github.io/2018/01/13/realtime-django-5.html)
   - [Part 6](https://danidee10.github.io/2018/03/12/realtime-django-6.html)
+- [Developing and Testing an Asynchronous API with FastAPI and Pytest](https://testdriven.io/blog/fastapi-crud/)
 
 ### Bots:
 


### PR DESCRIPTION
## Description
Added a FastAPI tutorial to the Python Web Applications section. The section had Flask and Django tutorials but was missing FastAPI.

## Motivation and Context
FastAPI is one of the most popular Python web frameworks right now, but there was no tutorial for it in the Web Applications section. The tutorial I'm adding is from testdriven.io, which is already referenced in the repo.

## How Has This Been Tested?
Verified the URL is valid and accessible. Checked for duplicates in the list.

## Types of changes
- [ ] Content Update (change which fixes an issue or updates an already existing submission)
- [x] New Article (change which adds functionality)
- [ ] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have made checks to ensure URLs and other resources are valid