### PR TITLE
Add hecto: Build your own text editor in Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
   - [Part 2](https://pwy.io/en/posts/learning-to-fly-pt2/)
   - [Part 3](https://pwy.io/en/posts/learning-to-fly-pt3/)
   - [Part 4](https://pwy.io/en/posts/learning-to-fly-pt4/)
+- [hecto: Build your own text editor in Rust](https://www.flenker.blog/hecto/)
 
 ## Scala:
 


### PR DESCRIPTION
## Description
Adds "hecto: Build your own text editor in Rust" to the Rust section.

hecto is a well-known, step-by-step tutorial that teaches Rust by building a fully functional text editor from scratch. It is widely used in the Rust learning community.

## Motivation
This tutorial was missing from the Rust section despite being a popular and high-quality resource for Rust learners.

## Link
https://www.flenker.blog/hecto/