### PR TITLE
Fixed Erlang Link 404 Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 ## Erlang
 
 - [ChatBus : build your first multi-user chat room app with Erlang/OTP](https://medium.com/@kansi/chatbus-build-your-first-multi-user-chat-room-app-with-erlang-otp-b55f72064901)
-- [Making a Chat App with Erlang, Rebar, Cowboy and Bullet](http://marianoguerra.org/posts/making-a-chat-app-with-erlang-rebar-cowboy-and-bullet.html)
+- [Making a Chat App with Erlang, Rebar, Cowboy and Bullet](https://web.archive.org/web/20150319224934/http://marianoguerra.org/posts/making-a-chat-app-with-erlang-rebar-cowboy-and-bullet.html) 
 
 ## F#:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The error was a 404 not found with the old link for the tutorial. I assumed it was just an outdated html file that doesn't work anymore. I used Wayback machine to find an archived version of this website, and replaced it with that old link. This makes the tutorial now accessible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I made this change because the tutorial is completely inaccessible to users who would like to access it, like the person who created the issue. This allows anyone to use the tutorial and link.
<!--- If it fixes an open issue, please link to the issue here. -->
Issue: https://github.com/practical-tutorials/project-based-learning/issues/840 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested the new link, checked if all the necessities are there, and had a friend test it as well. All works fine!
<!--- Include details of your testing environment, and the tests you ran to -->
I did not need much tests, as it was just a link.
<!--- see how your change affects other areas of the code, etc. -->
This does not affect any other code.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Content Update (change which fixes an issue or updates an already existing submission)
- [ ] New Article (change which adds functionality)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have made checks to ensure URLs and other resources are valid
