### PR TITLE
Add resource type tags guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,11 @@ Before making a pull request, please make sure of the following:
 * The pull request needs to have a descriptive title
 * If the language/technology of your tutorial does not exist, feel free to create a new entry in table of contents
 * Make a separate pull request for each of the tutorial
-* Use the following format `[Title](link_to_tutorial)`
+* Use the following format `[Title](link_to_tutorial) [guide]`
+* Append exactly one resource tag to each new tutorial entry: `[guide]`, `[video]`, `[course]`, `[book]`, or `[repo]`
 * If your tutorial is a multi-part series, use the following format:
     ```
-        * Title
+        * Title [guide]
             * [Part 1](link_to_part_1)
             * [Part 2](link_to_part_2)
     ```
@@ -18,5 +19,11 @@ Before making a pull request, please make sure of the following:
 * Do the work, write good commit messages, and read the CONTRIBUTING file if there is one
 * Remove any trailing whitespaces
 * Links must be pointing straight to the tutorials, no URL shorteners. However, if the URL is too long (more than 80 characters), Google URL Shortener is allowed
+
+### Entry format examples
+
+* `[Build an Interpreter](http://www.craftinginterpreters.com/) [book]`
+* `[Build an Android Flashlight App](https://www.youtube.com/watch?v=dhWL4DC7Krs) [video]`
+* `[Write an OS from scratch](https://github.com/tuhdo/os01) [repo]`
 
 Thank you for your suggestions! If you think there is anything to improve with the guidelines, please contact me at <tuvtran97@gmail.com>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ A list of programming tutorials in which aspiring software developers learn how 
 
 To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
+### Resource tags
+
+Use one resource-type tag at the end of each tutorial item:
+`[guide] [video] [course] [book] [repo]`
+
+Example:
+- [Build Your Own X](https://github.com/codecrafters-io/build-your-own-x) [repo]
+
 ## Table of Contents:
 
 - [C#](#c)
@@ -34,11 +42,11 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 ## C/C++:
 
-- [Build an Interpreter](http://www.craftinginterpreters.com/) (Chapter 14 on is written in C)
-- [Memory Allocators 101 - Write a simple memory allocator](https://arjunsreedharan.org/post/148675821737/memory-allocators-101-write-a-simple-memory)
-- [Write a Shell in C](https://brennan.io/2015/01/16/write-a-shell-in-c/)
-- [Write a FUSE Filesystem](https://www.cs.nmsu.edu/~pfeiffer/fuse-tutorial/)
-- [Build Your Own Text Editor](http://viewsourcecode.org/snaptoken/kilo/)
+- [Build an Interpreter](http://www.craftinginterpreters.com/) [book] (Chapter 14 on is written in C)
+- [Memory Allocators 101 - Write a simple memory allocator](https://arjunsreedharan.org/post/148675821737/memory-allocators-101-write-a-simple-memory) [guide]
+- [Write a Shell in C](https://brennan.io/2015/01/16/write-a-shell-in-c/) [guide]
+- [Write a FUSE Filesystem](https://www.cs.nmsu.edu/~pfeiffer/fuse-tutorial/) [guide]
+- [Build Your Own Text Editor](http://viewsourcecode.org/snaptoken/kilo/) [guide]
 - [Build Your Own Lisp](http://www.buildyourownlisp.com/)
 - [How to Program an NES Game in C](https://nesdoug.com/)
 - [Write an OS from scratch](https://github.com/tuhdo/os01)


### PR DESCRIPTION
## Summary
- add a small resource-tag legend near the top of the README
- document a single resource-type tag rule in CONTRIBUTING.md
- tag a few existing C/C++ entries as a pilot example instead of retagging the whole list

## Why this scope
- addresses #63 with a newcomer-friendly change
- keeps the taxonomy intentionally small: [guide], [video], [course], [book], [repo]
- avoids a noisy full-file retagging pass in the first PR

Closes #63
