### PR TITLE
Remove broken Medium links from JavaScript section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,11 @@ Before making a pull request, please make sure of the following:
 * The pull request needs to have a descriptive title
 * If the language/technology of your tutorial does not exist, feel free to create a new entry in table of contents
 * Make a separate pull request for each of the tutorial
-* Use the following format `[Title](link_to_tutorial)`
+* Use the following format `[Title](link_to_tutorial) [guide]`
+* Append exactly one resource tag to each new tutorial entry: `[guide]`, `[video]`, `[course]`, `[book]`, or `[repo]`
 * If your tutorial is a multi-part series, use the following format:
     ```
-        * Title
+        * Title [guide]
             * [Part 1](link_to_part_1)
             * [Part 2](link_to_part_2)
     ```
@@ -18,5 +19,11 @@ Before making a pull request, please make sure of the following:
 * Do the work, write good commit messages, and read the CONTRIBUTING file if there is one
 * Remove any trailing whitespaces
 * Links must be pointing straight to the tutorials, no URL shorteners. However, if the URL is too long (more than 80 characters), Google URL Shortener is allowed
+
+### Entry format examples
+
+* `[Build an Interpreter](http://www.craftinginterpreters.com/) [book]`
+* `[Build an Android Flashlight App](https://www.youtube.com/watch?v=dhWL4DC7Krs) [video]`
+* `[Write an OS from scratch](https://github.com/tuhdo/os01) [repo]`
 
 Thank you for your suggestions! If you think there is anything to improve with the guidelines, please contact me at <tuvtran97@gmail.com>

--- a/README.md
+++ b/README.md
@@ -219,9 +219,7 @@ Example:
 ## JavaScript:
 
 - [Build 30 things in 30 days with 30 tutorials](https://javascript30.com)
-- [Build an App in Pure JS](https://medium.com/codingthesmartway-com-blog/pure-javascript-building-a-real-world-application-from-scratch-5213591cfcd6)
 - [Build a Jupyter Notebook Extension](https://link.medium.com/wWUO7TN8SS)
-- [Build a TicTacToe Game with JavaScript](https://medium.com/javascript-in-plain-english/build-tic-tac-toe-game-using-javascript-3afba3c8fdcc)
 - [Build a Simple Weather App With Vanilla JavaScript](https://webdesign.tutsplus.com/tutorials/build-a-simple-weather-app-with-vanilla-javascript--cms-33893)
 - [Build a Todo List App in JavaScript](https://github.com/dwyl/javascript-todo-list-tutorial)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ A list of programming tutorials in which aspiring software developers learn how 
 
 To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
+### Resource tags
+
+Use one resource-type tag at the end of each tutorial item:
+`[guide] [video] [course] [book] [repo]`
+
+Example:
+- [Build Your Own X](https://github.com/codecrafters-io/build-your-own-x) [repo]
+
 ## Table of Contents:
 
 - [C#](#c)
@@ -34,11 +42,11 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 ## C/C++:
 
-- [Build an Interpreter](http://www.craftinginterpreters.com/) (Chapter 14 on is written in C)
-- [Memory Allocators 101 - Write a simple memory allocator](https://arjunsreedharan.org/post/148675821737/memory-allocators-101-write-a-simple-memory)
-- [Write a Shell in C](https://brennan.io/2015/01/16/write-a-shell-in-c/)
-- [Write a FUSE Filesystem](https://www.cs.nmsu.edu/~pfeiffer/fuse-tutorial/)
-- [Build Your Own Text Editor](http://viewsourcecode.org/snaptoken/kilo/)
+- [Build an Interpreter](http://www.craftinginterpreters.com/) [book] (Chapter 14 on is written in C)
+- [Memory Allocators 101 - Write a simple memory allocator](https://arjunsreedharan.org/post/148675821737/memory-allocators-101-write-a-simple-memory) [guide]
+- [Write a Shell in C](https://brennan.io/2015/01/16/write-a-shell-in-c/) [guide]
+- [Write a FUSE Filesystem](https://www.cs.nmsu.edu/~pfeiffer/fuse-tutorial/) [guide]
+- [Build Your Own Text Editor](http://viewsourcecode.org/snaptoken/kilo/) [guide]
 - [Build Your Own Lisp](http://www.buildyourownlisp.com/)
 - [How to Program an NES Game in C](https://nesdoug.com/)
 - [Write an OS from scratch](https://github.com/tuhdo/os01)


### PR DESCRIPTION
## Summary
- remove the broken Medium tutorial link for \Build an App in Pure JS\
- remove the broken Medium tutorial link for \Build a TicTacToe Game with JavaScript\
- keep the JavaScript section limited to working resources

Fixes #836