### PR TITLE
Add Streamlit section with beginner tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,3 +669,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 - [Enlight](https://enlight.nyc/)
 - [Hack Club Workshops](https://hackclub.com/workshops/)
 - [CodeCrafters](https://codecrafters.io/)
+
+
+## Streamlit
+-[Built Your First Streamlit App](https://docs.streamlit.io/get-started/tutorials/create-an-app)


### PR DESCRIPTION
Added a new Streamlit section under Python with an official beginner tutorial link from Streamlit docs.