### PR TITLE
Add Networking from Scratch to C/C++ network programming

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 ### Network programming
 
+- [Networking from Scratch](https://github.com/TanayK07/networking-from-scratch) - Build the network stack from raw bytes. 289 hands-on lessons in C and Python.
+
 - Let's Code a TCP/IP Stack
 
   - [Part 1: Ethernet & ARP](http://www.saminiir.com/lets-code-tcp-ip-stack-1-ethernet-arp/)


### PR DESCRIPTION
Adds [Networking from Scratch](https://github.com/TanayK07/networking-from-scratch) to the **C/C++ > Network programming** section.

289 hands-on lessons in C and Python covering the full network stack, from Ethernet frames to TLS 1.3.