### PR TITLE
Remove dead Erlang tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,6 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 ## Erlang
 
 - [ChatBus : build your first multi-user chat room app with Erlang/OTP](https://medium.com/@kansi/chatbus-build-your-first-multi-user-chat-room-app-with-erlang-otp-b55f72064901)
-- [Making a Chat App with Erlang, Rebar, Cowboy and Bullet](http://marianoguerra.org/posts/making-a-chat-app-with-erlang-rebar-cowboy-and-bullet.html)
 
 ## F#:
 


### PR DESCRIPTION
## Summary
- Remove an Erlang tutorial link that now returns 404

## Validation
- Confirmed the removed URL returns 404
- Confirmed the PR changes only README.md with one deleted line