### PR TITLE
Fix Rust linked lists resource link

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 - [Write an OS in pure Rust](https://os.phil-opp.com/)
 - [Build a browser engine in Rust](https://limpet.net/mbrubeck/2014/08/08/toy-layout-engine-1.html)
 - [Write a Microservice in Rust](http://www.goldsborough.me/rust/web/tutorial/2018/01/20/17-01-11-writing_a_microservice_in_rust/)
-- [Learning Rust with Too Many Linked Lists](http://cglab.ca/~abeinges/blah/too-many-lists/book/README.html)
+- [Learning Rust with Too Many Linked Lists](https://rust-unofficial.github.io/too-many-lists/)
 - Rust in Detail: Writing Scalable Chat Service from Scratch
   - [Part 1: Implementing WebSocket. Introduction.](https://nbaksalyar.github.io/2015/07/10/writing-chat-in-rust.html)
   - [Part 2: Sending and Receiving Messages](https://nbaksalyar.github.io/2015/11/09/rust-in-detail-2.html)


### PR DESCRIPTION
Fixes the broken README link for "Learning Rust with Too Many Linked Lists" in the Rust section.

Closes #858.

Validation:
- curl -I -L --max-time 20 http://cglab.ca/~abeinges/blah/too-many-lists/book/README.html -> 301 then 404
- curl -I -L --max-time 20 https://rust-unofficial.github.io/too-many-lists/ -> 200
- git diff --check -> passed