### PR TITLE
Fix Go websocket tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 ## Go:
 
-- [Create a Real Time Chat App with Golang, Angular 2, and WebSocket](https://www.thepolyglotdeveloper.com/2016/12/create-real-time-chat-app-golang-angular-2-websockets/)
+- [Create a Real Time Chat App with Golang, Angular 2, and WebSocket](https://web.archive.org/web/20260214230813/https://www.thepolyglotdeveloper.com/2016/12/create-real-time-chat-app-golang-angular-2-websockets/)
 - [Building Go Web Applications and Microservices Using Gin](https://semaphoreci.com/community/tutorials/building-go-web-applications-and-microservices-using-gin)
 - [How to Use Godog for Behavior-driven Development in Go](https://semaphoreci.com/community/tutorials/how-to-use-godog-for-behavior-driven-development-in-go)
 - Building Blockchain in Go


### PR DESCRIPTION
Fixes the broken README link for the Go realtime chat tutorial by pointing it to an archived copy of the original article.

Closes #859.

Validation:
- curl -L -o /dev/null -s -w 'old %{http_code} %{url_effective}\n' https://www.thepolyglotdeveloper.com/2016/12/create-real-time-chat-app-golang-angular-2-websockets/ -> 404
- curl -L -o /dev/null -s -w 'new %{http_code} %{url_effective}\n' https://web.archive.org/web/20260214230813/https://www.thepolyglotdeveloper.com/2016/12/create-real-time-chat-app-golang-angular-2-websockets/ -> 200
- git diff --check -> passed