### PR TITLE
Update Write You A Scheme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 - [Write You a Haskell - Build a modern functional compiler](http://dev.stephendiehl.com/fun/)
 - [Write Yourself a Scheme in 48 hours](https://en.wikibooks.org/wiki/Write_Yourself_a_Scheme_in_48_Hours)
-- [Write You A Scheme, Version 2](https://github.com/write-you-a-scheme-v2/scheme)
+- [Write You A Scheme, Version 2](https://github.com/adamwespiser/scheme)
 - [Roll Your Own IRC Bot](https://wiki.haskell.org/Roll_your_own_IRC_bot)
 - [Making Movie Monad](https://lettier.github.io/posts/2016-08-15-making-movie-monad.html)
 - [Making a Website with Haskell **(outdated)**](http://adit.io/posts/2013-04-15-making-a-website-with-haskell.html)


### PR DESCRIPTION
## Summary
- Update the Write You A Scheme, Version 2 link to its canonical GitHub repository

## Verification
- `git diff --check`
- Confirmed the previous GitHub URL redirects to the updated destination
- Confirmed the updated GitHub URL returns `200` directly