### PR TITLE
Fix dead 'Build a Reddit Bot' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 ### Bots:
 
-- [Build a Reddit Bot](http://pythonforengineers.com/build-a-reddit-bot-part-1/)
+- [Build a Reddit Bot](https://www.pythonforengineers.com/blog/build-a-reddit-bot-part-1/)
 - [How to Make a Reddit Bot - YouTube](https://www.youtube.com/watch?v=krTUf7BpTc0) (video)
 - [Build a Facebook Messenger Bot](https://blog.hartleybrody.com/fb-messenger-bot/)
 - [Making a Reddit + Facebook Messenger Bot](https://pythontips.com/2017/04/13/making-a-reddit-facebook-messenger-bot/)


### PR DESCRIPTION
The pythonforengineers.com "Build a Reddit Bot" tutorial moved. The old URL `http://pythonforengineers.com/build-a-reddit-bot-part-1/` returns **404**; the same article is live at `https://www.pythonforengineers.com/blog/build-a-reddit-bot-part-1/` (HTTP 200). This points the entry at the current location — same author, same content, one-line change.