### PR TITLE
Add tutorial: Build a JSON Parser (Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 - [Build a Simple Interpreter](https://ruslanspivak.com/lsbasi-part1/)
 - [Build a Simple Blockchain in Python](https://hackernoon.com/learn-blockchains-by-building-one-117428612f46)
 - [Write a NoSQL Database in Python](https://jeffknupp.com/blog/2014/09/01/what-is-a-nosql-database-learn-by-writing-one-in-python/)
+- [Build a JSON Parser](https://shipthatcode.com/courses/build-json-parser)
 - [Building a Gas Pump Scanner with OpenCV/Python/iOS](https://hackernoon.com/building-a-gas-pump-scanner-with-opencv-python-ios-116fe6c9ae8b)
 - [Build a Distributed Streaming System with Python and Kafka](https://codequs.com/p/S14jQ5UyG/build-a-distributed-streaming-system-with-apache-kafka-and-python)
 - [Writing a basic x86-64 JIT compiler from scratch in stock Python](https://csl.name/post/python-jit/)


### PR DESCRIPTION
Adds [Build a JSON Parser](https://shipthatcode.com/courses/build-json-parser) under Python.

It's a free, interactive course where you build a JSON parser from scratch — tokenizer, recursive-descent value parser, full string-escape handling including \uXXXX surrogate pairs, and the strict number grammar — running your code against tests as you go.

There's no JSON parser tutorial in the list yet, so this fills a gap. Placed under Python and formatted per CONTRIBUTING.md.