### PR TITLE
Add tutorial: Build a DNS Server (Go)

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
   - [Part 4 - Forwarding](https://www.eddywm.com/lets-build-a-url-shortener-in-go-part-iv-forwarding/)
 - [Building a TCP Chat in Go(video)](https://www.youtube.com/watch?v=Sphme0BqJiY)
 - [Building a BitTorrent client from the ground up in Go](https://blog.jse.li/posts/torrent/)
+- [Build a DNS Server](https://shipthatcode.com/courses/build-dns-server)
 - [REST API masterclass with Go, PostgreSQL and Docker(video playlist)`in progress`](https://www.youtube.com/watch?v=rx6CPDK_5mU&list=PLy_6D98if3ULEtXtNSY_2qN21VCKgoQAE)
 
 ## PHP:


### PR DESCRIPTION
Adds [Build a DNS Server](https://shipthatcode.com/courses/build-dns-server) under Go.

A free, interactive course where you implement DNS from scratch — the 12-byte header, name encoding with compression pointers, the question/resource-record wire format, and A/AAAA/MX/SRV/SOA records — writing byte-exact code and running it against tests.

No DNS tutorial exists in the list yet, so this fills a gap. Placed under Go and formatted per CONTRIBUTING.md.