### PR TITLE
Fix Reddit bot tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 ### Bots:
 
-- [Build a Reddit Bot](http://pythonforengineers.com/build-a-reddit-bot-part-1/)
+- [Build a Reddit Bot](https://web.archive.org/web/20251008183102/https://pythonforengineers.com/blog/build-a-reddit-bot-part-1/index.html)
 - [How to Make a Reddit Bot - YouTube](https://www.youtube.com/watch?v=krTUf7BpTc0) (video)
 - [Build a Facebook Messenger Bot](https://blog.hartleybrody.com/fb-messenger-bot/)
 - [Making a Reddit + Facebook Messenger Bot](https://pythontips.com/2017/04/13/making-a-reddit-facebook-messenger-bot/)


### PR DESCRIPTION
## Summary
- Updates the broken Build a Reddit Bot tutorial link in the Python Bots section.
- Uses a working Wayback Machine capture of the original Python for Engineers tutorial.

## Validation
- Verified the old link no longer resolves in this environment.
- Verified the archived tutorial loads successfully.
- Ran git diff --check.

Closes #761