### PR TITLE
docs: fix broken Erlang chat tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 ## Erlang
 
 - [ChatBus : build your first multi-user chat room app with Erlang/OTP](https://medium.com/@kansi/chatbus-build-your-first-multi-user-chat-room-app-with-erlang-otp-b55f72064901)
-- [Making a Chat App with Erlang, Rebar, Cowboy and Bullet](http://marianoguerra.org/posts/making-a-chat-app-with-erlang-rebar-cowboy-and-bullet.html)
+- [Making a Chat App with Erlang, Rebar, Cowboy and Bullet](https://web.archive.org/web/20150319224934/http://marianoguerra.org/posts/making-a-chat-app-with-erlang-rebar-cowboy-and-bullet.html)
 
 ## F#:
 


### PR DESCRIPTION
## Description
Updates the Erlang "Making a Chat App with Erlang, Rebar, Cowboy and Bullet" entry to point to an archived copy of the original tutorial.

## Motivation and Context
The current `marianoguerra.org` URL returns 404 Not Found. This fixes #840 by preserving the original tutorial through the Wayback Machine instead of leaving a broken link in the README.

## How Has This Been Tested?
- `git diff --check`
- Verified the old URL returns `HTTP Error 404: Not Found`
- Verified the replacement archive URL returns `200` and contains the tutorial title

## Types of changes
- [x] Content Update (change which fixes an issue or updates an already existing submission)
- [ ] New Article (change which adds functionality)
- [x] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have made checks to ensure URLs and other resources are valid
