### PR TITLE
docs: remove outdated URL shortener guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,6 @@ Before making a pull request, please make sure of the following:
 * Check the spelling and grammar
 * Do the work, write good commit messages, and read the CONTRIBUTING file if there is one
 * Remove any trailing whitespaces
-* Links must be pointing straight to the tutorials, no URL shorteners. However, if the URL is too long (more than 80 characters), Google URL Shortener is allowed
+* Links must be pointing straight to the tutorials, no URL shorteners
 
 Thank you for your suggestions! If you think there is anything to improve with the guidelines, please contact me at <tuvtran97@gmail.com>


### PR DESCRIPTION
## Description
Updates `CONTRIBUTING.md` to remove the exception that allowed Google URL Shortener for long tutorial URLs.

## Motivation and Context
The contribution guide already requires tutorial links to point straight to the tutorial and not use URL shorteners. The following sentence made an exception for Google URL Shortener, but Google's official developer blog says goo.gl links are being discontinued and will no longer be available. Removing the exception keeps the guideline consistent and avoids encouraging contributors to submit shortened links.

Reference: https://developers.googleblog.com/en/google-url-shortener-links-will-no-longer-be-available/

## How Has This Been Tested?
- Ran `git diff --check`
- Verified the change is a one-line documentation-only update

## Types of changes
- [ ] Content Update (change which fixes an issue or updates an already existing submission)
- [ ] New Article (change which adds functionality)
- [x] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have made checks to ensure URLs and other resources are valid
