### PR TITLE
Fix cryptocurrency bot tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 ## R:
 
 - [Build Web Apps with Shiny](http://shiny.rstudio.com/tutorial/)
-- [Build A Cryptocurrency Bot](https://towardsdatascience.com/build-a-cryptocurrency-trading-bot-with-r-1445c429e1b1)
+- [Build A Cryptocurrency Bot](https://medium.com/data-science/build-a-cryptocurrency-trading-bot-with-r-1445c429e1b1)
 - [Learn Associate Rule Mining in R](https://towardsdatascience.com/association-rule-mining-in-r-ddf2d044ae50)
 
 ## Rust:


### PR DESCRIPTION
Fixes #730. Summary: Updates the broken cryptocurrency bot tutorial link to the current Medium URL for the original article. Validation: confirmed the old URL resolves to a different article, confirmed the new URL loads the intended tutorial, and ran git diff --check.