### PR TITLE
Fix Meta Crush Saga tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
   - [Part 9: Functions](https://norasandler.com/2018/06/27/Write-a-Compiler-9.html)
   - [Part 10: Global Variables](https://norasandler.com/2019/02/18/Write-a-Compiler-10.html)
 - [Implementing a Language with LLVM](https://llvm.org/docs/tutorial/#kaleidoscope-implementing-a-language-with-llvm)
-- [Meta Crush Saga: a C++17 compile-time game](https://jguegant.github.io//jguegant.github.io/blogs/tech/meta-crush-saga.html)
+- [Meta Crush Saga: a C++17 compile-time game](https://jguegant.github.io/blogs/tech/meta-crush-saga.html)
 - [High-Performance Matrix Multiplication](https://gist.github.com/nadavrot/5b35d44e8ba3dd718e595e40184d03f0)
 - Space Invaders from Scratch
   - [Part 1](http://nicktasios.nl/posts/space-invaders-from-scratch-part-1.html)


### PR DESCRIPTION
## Summary
- Fixes the malformed Meta Crush Saga URL in the C/C++ section.
- Removes the duplicated jguegant.github.io path segment so the link points to the live article.

## Testing
- Verified the corrected URL returns HTTP 200.
- Ran git diff --check.

Related to #899.