### PR TITLE
Fix malformed URL for Meta Crush Saga tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
   - [Part 9: Functions](https://norasandler.com/2018/06/27/Write-a-Compiler-9.html)
   - [Part 10: Global Variables](https://norasandler.com/2019/02/18/Write-a-Compiler-10.html)
 - [Implementing a Language with LLVM](https://llvm.org/docs/tutorial/#kaleidoscope-implementing-a-language-with-llvm)
-- [Meta Crush Saga: a C++17 compile-time game](https://jguegant.github.io//jguegant.github.io/blogs/tech/meta-crush-saga.html)
+- [Meta Crush Saga: a C++17 compile-time game](https://jguegant.github.io/blogs/tech/meta-crush-saga.html)
 - [High-Performance Matrix Multiplication](https://gist.github.com/nadavrot/5b35d44e8ba3dd718e595e40184d03f0)
 - Space Invaders from Scratch
   - [Part 1](http://nicktasios.nl/posts/space-invaders-from-scratch-part-1.html)


### PR DESCRIPTION
<!--- One tutorial per pull request, please -- it makes review much faster. -->

## What is this?

- Title: Meta Crush Saga: a C++17 compile-time game
- URL: https://jguegant.github.io/blogs/tech/meta-crush-saga.html
- Section: C/C++

## Checklist

- [x] This PR adds/fixes exactly one tutorial (or is a docs/tooling-only change).
- [x] Free and open -- no paywall, login wall, or required newsletter signup.
- [x] Project-based -- following it, the reader builds a complete, working artifact.
- [x] I searched README.md for this URL and title -- it is not already listed.
- [x] Entry uses `- [Title](https://...)` format, placed under the correct section (nested `- [Part N](...)` for multi-part series).
- [x] No URL shorteners.
- [x] I ran `python3 scripts/check_readme.py lint` locally and it exits 0.
- [x] Relationship disclosure: no relationship to the author.
