### PR TITLE
fix(docs): fix broken Wayback Machine archive link for Go chat app tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 ## Go:
 
-- [Create a Real Time Chat App with Golang, Angular 2, and WebSocket](https://web.archive.org/web/20260214230813/https://www.thepolyglotdeveloper.com/2016/12/create-real-time-chat-app-golang-angular-2-websockets/)
+- [Create a Real Time Chat App with Golang, Angular 2, and WebSocket](https://web.archive.org/web/20200926061218/https://www.thepolyglotdeveloper.com/2016/12/create-real-time-chat-app-golang-angular-2-websockets/)
 - [Building Go Web Applications and Microservices Using Gin](https://semaphoreci.com/community/tutorials/building-go-web-applications-and-microservices-using-gin)
 - [How to Use Godog for Behavior-driven Development in Go](https://semaphoreci.com/community/tutorials/how-to-use-godog-for-behavior-driven-development-in-go)
 - Building Blockchain in Go


### PR DESCRIPTION
## Description
This PR resolves issue #888 by updating the archive URL for the Golang, Angular 2, and WebSocket Real-Time Chat App tutorial in `README.md` to a valid snapshot.