### PR TITLE
Add Android tutorial in Kotlin to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 ## Kotlin:
 
 - [Keddit - Learn Kotlin While Developing an Android Application](https://medium.com/@juanchosaravia/learn-kotlin-while-developing-an-android-app-introduction-567e21ff9664)
+- [Build Your First Android App in Kotlin](https://developer.android.com/codelabs/basic-android-kotlin-compose-first-app)
 
 ## Lua:
 


### PR DESCRIPTION
<!--- One tutorial per pull request, please -- it makes review much faster. -->

## What is this?

- Title:
- URL:
- Section:

## Checklist

- [x] This PR adds/fixes exactly one tutorial (or is a docs/tooling-only change).
- [x] Free and open -- no paywall, login wall, or required newsletter signup.
- [x] Project-based -- following it, the reader builds a complete, working artifact.
- [x] I searched README.md for this URL and title -- it is not already listed.
- [x] Entry uses `- [Title](https://...)` format, placed under the correct section (nested `- [Part N](...)` for multi-part series).
- [x] No URL shorteners.
- [x] I ran `python3 scripts/check_readme.py lint` locally and it exits 0.
- [x] Relationship disclosure: no relationship to the author .
