### PR TITLE
Add 'Build Your Own Physics' under Python (Physics / Simulations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,10 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 - [Build A Desktop Chat App with React and Electron](https://medium.freecodecamp.org/build-a-desktop-chat-app-with-react-electron-and-chatkit-744d168e6f2f)
 
+### Physics / Simulations:
+
+- [Build Your Own Physics — Master physics by recreating 12 simulations from scratch, from projectile motion to the solar system](https://github.com/Zensoro/build-your-own-physics)
+
 ### Miscellaneous:
 
 - [How to Build a Web Framework in Less Than 20 Lines of Code](https://www.pubnub.com/blog/build-yourself-a-web-framework-in-less-than-20-lines-of-code/)


### PR DESCRIPTION
Adds "Build Your Own Physics" — a free, zero-prerequisite curriculum of 12 Python projects where learners recreate physics simulations from scratch (projectile motion, pendulum, orbital mechanics, N-body gravity, waves, a Carnot heat engine, double pendulum chaos, fluid dynamics, electromagnetism, special relativity, quantum tunneling, and a full solar system).

Each project ships a SPEC, a starter scaffold with TODOs, a verified reference solution, and an automatic grader (GitHub Actions grades all 12 on every push/PR). The repo is bilingual (中文/English), MIT-licensed, and aimed at complete beginners.

I placed it in a new "Physics / Simulations" sub-section under Python, matching the existing "build it from scratch" spirit of this list.