### PR TITLE
Remove spam Yelp tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,6 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 - [Create Serverless React.js Apps](http://serverless-stack.com/)
 - [Create a Trello Clone](http://codeloveandboards.com/blog/2016/01/04/trello-tribute-with-phoenix-and-react-pt-1/)
 - [Create a Character Voting App with React, Node, MongoDB and SocketIO](http://sahatyalkabov.com/create-a-character-voting-app-using-react-nodejs-mongodb-and-socketio)
-- [React Tutorial: Cloning Yelp](https://www.fullstackreact.com/articles/react-tutorial-cloning-yelp/)
 - [Build a Full Stack Movie Voting App with Test-First Development using Mocha, React, Redux and Immutable](https://teropa.info/blog/2015/09/10/full-stack-redux-tutorial.html)
 - [Build A Simple Medium Clone using React.js and Node.js](https://medium.com/@kris101/clone-medium-on-node-js-and-react-js-731cdfbb6878)
 - [Integrate MailChimp in JS](https://medium.freecodecamp.org/how-to-integrate-mailchimp-in-a-javascript-web-app-2a889fb43f6f)


### PR DESCRIPTION
## What is this?

- Title: React Tutorial: Cloning Yelp
- URL: https://www.fullstackreact.com/articles/react-tutorial-cloning-yelp/
- Section: JavaScript / Web Applications / React

## Why

The listed URL no longer serves the tutorial. It returns a small page that redirects visitors to /lander, matching the spam redirect reported in the issue. This removes the unsafe and unusable entry without adding an unverified replacement.

## Checklist

- [x] This PR fixes exactly one tutorial entry.
- [x] I ran python scripts/check_readme.py lint locally and it exits 0.
- [x] No replacement URL or URL shortener was added.
- [x] Relationship disclosure: no relationship to the author or site.

Fixes #719