### PR TITLE
refactor(scripts): remove unused timezone import in check_readme.py

### DIFF
--- a/scripts/check_readme.py
+++ b/scripts/check_readme.py
@@ -26,7 +26,7 @@ import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import date, timezone
+from datetime import date
 from html.parser import HTMLParser
 from urllib.parse import urljoin, urlsplit
 


### PR DESCRIPTION
## Description

Removes unused `timezone` import from `datetime` in `scripts/check_readme.py`.