### PR TITLE
fix: update tinyrenderer's (obsolete) tutorial link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 - [Beginning Game Programming with C++ and SDL](http://lazyfoo.net/tutorials/SDL/)
 - [Implementing a Key-Value Store](http://codecapsule.com/2012/11/07/ikvs-implementing-a-key-value-store-table-of-contents/)
 - Tiny 3D graphics projects
-  - [Tiny Renderer or how OpenGL works: software rendering in 500 lines of code](https://github.com/ssloy/tinyrenderer/wiki)
+  - [Tiny Renderer or how OpenGL works: software rendering in 500 lines of code](https://haqr.eu/tinyrenderer/)
   - [Understandable RayTracing in 256 lines of bare C++](https://github.com/ssloy/tinyraytracer/wiki)
   - [KABOOM! in 180 lines of bare C++](https://github.com/ssloy/tinykaboom/wiki)
   - [486 lines of C++: old-school FPS in a weekend](https://github.com/ssloy/tinyraycaster/wiki)


### PR DESCRIPTION
<!--- One tutorial per pull request, please -- it makes review much faster. -->

## What is this?

- Title: Tiny Renderer or how OpenGL works: software rendering in 500 lines of code
- URL: https://haqr.eu/tinyrenderer/
- Section: C/C++

## Checklist

- [x] This PR adds/fixes exactly one tutorial (or is a docs/tooling-only change).
- [x] Free and open -- no paywall, login wall, or required newsletter signup.
- [x] Project-based -- following it, the reader builds a complete, working artifact.
- [ ] I searched README.md for this URL and title -- it is not already listed.
- [ ] Entry uses `- [Title](https://...)` format, placed under the correct section (nested `- [Part N](...)` for multi-part series).
- [x] No URL shorteners.
- [x] I ran `python3 scripts/check_readme.py lint` locally and it exits 0.
- [x] Relationship disclosure: no relationship to the author.
