### PR TITLE
fix: replace dead ardendertat.com links with Wayback Machine archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,9 +517,9 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
   - [Part 1](https://blog.asrpo.com/making_a_low_level_debugger)
   - [Part 2: C](https://blog.asrpo.com/making_a_low_level_debugger_part_2)
 - Implementing a Search Engine
-  - [Part 1](http://www.ardendertat.com/2011/05/30/how-to-implement-a-search-engine-part-1-create-index/)
-  - [Part 2](http://www.ardendertat.com/2011/05/31/how-to-implement-a-search-engine-part-2-query-index/)
-  - [Part 3](http://www.ardendertat.com/2011/07/17/how-to-implement-a-search-engine-part-3-ranking-tf-idf/)
+  - [Part 1](http://web.archive.org/web/20200116152107/http://www.ardendertat.com/2011/05/30/how-to-implement-a-search-engine-part-1-create-index/)
+  - [Part 2](http://web.archive.org/web/20200118151553/http://www.ardendertat.com/2011/05/31/how-to-implement-a-search-engine-part-2-query-index/)
+  - [Part 3](http://web.archive.org/web/20200117190308/http://www.ardendertat.com/2011/07/17/how-to-implement-a-search-engine-part-3-ranking-tf-idf/)
 - [Build the Game of Life](https://robertheaton.com/2018/07/20/project-2-game-of-life/)
 - [Create terminal ASCII art](https://robertheaton.com/2018/06/12/programming-projects-for-advanced-beginners-ascii-art/)
 - [Write a Tic-Tac-Toe AI](https://robertheaton.com/2018/10/09/programming-projects-for-advanced-beginners-3-a/)


### PR DESCRIPTION
## What is this?

- Title: Implementing a Search Engine (Parts 1-3)
- URL: http://web.archive.org/web/20200116152107/http://www.ardendertat.com/2011/05/30/how-to-implement-a-search-engine-part-1-create-index/
- Section: Python

The original links point to ardendertat.com which now returns a database connection error. Replaced all three parts with their most recent working Wayback Machine snapshots (January 2020).

Closes #380

## Checklist

- [x] This PR adds/fixes exactly one tutorial (or is a docs/tooling-only change).
- [x] Free and open -- no paywall, login wall, or required newsletter signup. (Wayback Machine is free)
- [x] Project-based -- following it, the reader builds a complete, working artifact. (original series was project-based)
- [x] I searched README.md for this URL and title -- it is not already listed.
- [x] Entry uses `- [Title](https://...)` format, placed under the correct section (nested `- [Part N](...)` for multi-part series).
- [x] No URL shorteners.
- [x] I ran `python3 scripts/check_readme.py lint` locally and it exits 0.
- [x] Relationship disclosure: no relationship to the author.