### PR TITLE
fix(docs): replace 3 dead links with working alternatives

### DIFF
--- a/.oss-upstream
+++ b/.oss-upstream
@@ -1,0 +1,1 @@
+﻿practical-tutorials/project-based-learning

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 - [Create Serverless React.js Apps](http://serverless-stack.com/)
 - [Create a Trello Clone](http://codeloveandboards.com/blog/2016/01/04/trello-tribute-with-phoenix-and-react-pt-1/)
-- [Create a Character Voting App with React, Node, MongoDB and SocketIO](http://sahatyalkabov.com/create-a-character-voting-app-using-react-nodejs-mongodb-and-socketio)
+- [Create a Character Voting App with React, Node, MongoDB and SocketIO](http://web.archive.org/web/20230205102548/http://sahatyalkabov.com/create-a-character-voting-app-using-react-nodejs-mongodb-and-socketio/)
 - [React Tutorial: Cloning Yelp](https://www.fullstackreact.com/articles/react-tutorial-cloning-yelp/)
 - [Build a Full Stack Movie Voting App with Test-First Development using Mocha, React, Redux and Immutable](https://teropa.info/blog/2015/09/10/full-stack-redux-tutorial.html)
 - [Build A Simple Medium Clone using React.js and Node.js](https://medium.com/@kris101/clone-medium-on-node-js-and-react-js-731cdfbb6878)
@@ -612,7 +612,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 
 ## Haskell:
 
-- [Write You a Haskell - Build a modern functional compiler](http://dev.stephendiehl.com/fun/)
+- [Write You a Haskell - Build a modern functional compiler](https://github.com/sdiehl/write-you-a-haskell)
 - [Write Yourself a Scheme in 48 hours](https://en.wikibooks.org/wiki/Write_Yourself_a_Scheme_in_48_Hours)
 - [Write You A Scheme, Version 2](https://github.com/adamwespiser/scheme)
 - [Roll Your Own IRC Bot](https://wiki.haskell.org/Roll_your_own_IRC_bot)
@@ -670,7 +670,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 - [Exercism](http://www.exercism.io/)
 - [Egghead.io](http://www.egghead.io/)
 - [Michael Herman's Blog](http://mherman.org/)
-- [Thinkster.io](http://thinkster.io)
+- [Thinkster.io](http://web.archive.org/web/20250922175418/https://thinkster.io/)
 - [Enlight](https://enlight.nyc/)
 - [Hack Club Workshops](https://hackclub.com/workshops/)
 - [CodeCrafters](https://codecrafters.io/)


### PR DESCRIPTION
## What is this?

This is a docs-only change that replaces three dead links reported in issue #900.

| Original URL | Status | Replacement |
|---|---|---|
| `http://sahatyalkabov.com/create-a-character-voting-app-using-react-nodejs-mongodb-and-socketio` | 404 | Wayback Machine snapshot (2023-02-05) â€” full article preserved |
| `http://dev.stephendiehl.com/fun/` | Timeout / unreachable | Official GitHub repo: `https://github.com/sdiehl/write-you-a-haskell` |
| `http://thinkster.io` (Resources section) | DNS resolution failed | Wayback Machine snapshot (2025-09-22) |

All three replacement URLs return HTTP 200. `python3 scripts/check_readme.py lint` exits with `errors=0 warnings=0`.

## Checklist

- [x] This PR adds/fixes exactly one tutorial (or is a docs/tooling-only change).
- [x] Free and open -- no paywall, login wall, or required newsletter signup.
- [x] Project-based -- following it, the reader builds a complete, working artifact.
- [x] I searched README.md for this URL and title -- it is not already listed.
- [x] Entry uses `- [Title](https://...)` format, placed under the correct section (nested `- [Part N](...)` for multi-part series).
- [x] No URL shorteners.
- [x] I ran `python3 scripts/check_readme.py lint` locally and it exits 0.
- [x] Relationship disclosure: no relationship to the author.

Fixes #900
