### PR TITLE
Add Python LangChain RAG tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
   - [Part 6](https://danidee10.github.io/2018/03/12/realtime-django-6.html)
 - [Creating APIs with Python - Comprehensive Course for Beginners (video)](https://www.freecodecamp.org/news/creating-apis-with-python-free-19-hour-course/)
 - [Build Your First Streamlit Data App](https://docs.streamlit.io/get-started/tutorials/create-an-app)
+- [Build a simple LangChain RAG application](https://github.com/pixegami/langchain-rag-tutorial)
 
 ### Bots:
 


### PR DESCRIPTION
### What
Adds a Python tutorial: build a simple LangChain RAG application.

### Why it fits
- Free and open: yes (public GitHub repo, no paywall, no login wall)
- Project-based: builds a working Q&A bot over local documents using LangChain + ChromaDB
- Source: https://github.com/pixegami/langchain-rag-tutorial

### Affiliation
I am not the author of this tutorial.
